### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The #to_s method will be removed from EtcUtils in release 1.0.0 (see feature/cla
 
 Moving forward, please use #to_entry in-place of #to_s.  See [parse](#parse) for more.
 
-I apologize for the inconvience.
+I apologize for the inconvenience.
 
 
 ## Know Issues


### PR DESCRIPTION
## Summary
- fix spelling of "inconvenience" in README

## Testing
- `bundle exec rake test` *(fails: Could not find gem 'rake-compiler' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_683f67209d148326ad96f61dae96141b