### PR TITLE
Fix README header typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Moving forward, please use #to_entry in-place of #to_s.  See [parse](#parse) for
 I apologize for the inconvience.
 
 
-## Know Issues
+## Known Issues
 
 Verified on Ubuntu 12.04, nsswitch.conf is misconfigured due to a known [bug](http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=699089).  You will be unable to manipulate /etc/gshadow until this line is added to /etc/nsswitch.conf.
 


### PR DESCRIPTION
## Summary
- fix minor typo in README section heading

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec rake test` *(fails: missing gem 'rake-compiler')*

------
https://chatgpt.com/codex/tasks/task_e_683f6745ac608326a6f28d2ccb4def64